### PR TITLE
Fib.ts fix by adding typings to the variables

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n: number): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
This PR resolves TypeScript compilation errors in src/fib.ts by adding proper type annotations. The function parameter n was implicitly typed as any, causing TypeScript to throw errors about unsafe arithmetic operations and unsafe return values. Added explicit number type annotations to both the parameter (n: number) and return type (: number), ensuring type safety and eliminating the "Invalid operand for '+' operation" and "Unsafe return of any typed value" errors.